### PR TITLE
Cierra issues abiertos de objetivos anteriores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Ignorar archivos .DS_Store generados por macOS
 .DS_Store
+
+.vscode


### PR DESCRIPTION
Aparte de añadir esta carpeta al .gitignore (que no tiene nada que ver con los objetivos) se cierran los issues abiertos de objetivos anteriores.

closes #15
closes #16
closes #17
closes #31
closes #47 